### PR TITLE
Fix OBO for out-of-range syscalls

### DIFF
--- a/arch/ish/kernel/process.c
+++ b/arch/ish/kernel/process.c
@@ -78,7 +78,7 @@ static void __user_thread(void)
 						 unsigned long, unsigned long,
 						 unsigned long, unsigned long);
 
-			if (regs->orig_ax > NR_syscalls) {
+			if (regs->orig_ax >= NR_syscalls) {
 				show_signal(current, "syscall out of range", regs->orig_ax);
 				force_sig_fault(SIGSYS, SI_KERNEL, 0);
 				goto signal;


### PR DESCRIPTION
Fixes EXC_BAD_ACCESS when `regs->orig_ax == NR_syscalls`

<img width="909" alt="image" src="https://user-images.githubusercontent.com/52170171/200095705-41692459-3569-47e0-9006-84bca5a481d3.png">
